### PR TITLE
feat(service): add axios config to the service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.0.5",
+      "name": "playwright-zephyr",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.24.0",

--- a/src/zephyr.service.ts
+++ b/src/zephyr.service.ts
@@ -39,6 +39,7 @@ export class ZephyrService {
         'Content-Type': 'application/json',
         Authorization: `Basic ${this.authorizationToken}`,
       },
+      ...options,
     });
   }
 

--- a/types/zephyr.types.ts
+++ b/types/zephyr.types.ts
@@ -1,17 +1,19 @@
-export type ZephyrOptions = {
-  host: string,
-  user?: string,
-  password?: string,
-  authorizationToken?: string,
-  projectKey: string
+import type { AxiosRequestConfig } from 'axios';
+
+export interface ZephyrOptions extends AxiosRequestConfig {
+  host: string;
+  user?: string;
+  password?: string;
+  authorizationToken?: string;
+  projectKey: string;
 }
 
 export type ZephyrStatus = 'Pass' | 'Fail' | 'Blocked' | 'Not Executed' | 'In Progress';
 
 export type ZephyrTestResult = {
-  testCaseKey: string,
-  status: ZephyrStatus,
-  environment?: string,
-  executionTime?: string,
-  executionDate?: string
-}
+  testCaseKey: string;
+  status: ZephyrStatus;
+  environment?: string;
+  executionTime?: string;
+  executionDate?: string;
+};


### PR DESCRIPTION
```typescript
const config: PlaywrightTestConfig = {
  reporter: [['playwright-zephyr', { 
  host: 'https://your-zephyr.cloud.com',
  user: '<your-user>',
  password: '<your-password>',
  projectKey: '<your-project-key>',
  proxy: false,
  httpsAgent: new https.Agent({
    requestcert: true,
    rejectUnauthorized: false,
    baseURL: 'https://your-zephyr.cloud.com',
    proxy: {
      host: 'localhost',
      port: 3128,
    },
  }),
  }]],
}
```