### PR TITLE
decode error message with ansi regex

### DIFF
--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -31,16 +31,11 @@ export default class ZephyrReporter implements Reporter {
       const [, testCaseId] = test.title.match(this.testCaseKeyPattern)!;
       const testCaseKey = `${this.projectKey}-${testCaseId}`;
       const status = convertStatus(result.status);
+      const ansiRegex = /(\x1b\[[0-9;]+m)/g;
       const comment = result.error
-        ? `<b>❌ Error Message: </b> <br> <span style="color: rgb(226, 80, 65);">${result.error?.message?.replaceAll(
-            '\n',
-            '<br>',
-          )}</span> <br> <br> <b>🧱 Stack Trace:</b> <br> <span style="color: rgb(226, 80, 65);">${result.error?.stack?.replaceAll(
-            '\n',
-            '<br>',
-          )}</span>`
+        ? `<b>❌ Error Message: </b> <br> <span style="color: rgb(226, 80, 65);">${result.error?.message?.replace(ansiRegex, '')}
+        </span> <br> <br> <b>🧱 Stack Trace:</b> <br> <span style="color: rgb(226, 80, 65);">${result.error?.stack?.replace(ansiRegex, '')}</span>`
         : undefined;
-
       this.testResults.push({
         result: status,
         testCase: {


### PR DESCRIPTION
Hey
This is the fix for a submitted bug: https://github.com/elaichenkov/playwright-zephyr/issues/45

Please check the comment without and with decoding:
![2024-03-01_10-33](https://github.com/elaichenkov/playwright-zephyr/assets/11655108/8b39b868-960c-4266-9454-89a4df87341b)
![2024-03-01_10-30](https://github.com/elaichenkov/playwright-zephyr/assets/11655108/4c2f200f-dac4-4c35-a3ce-eae6d3119e72)

