### PR TITLE
update status for zephyr

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,8 @@ import type { Reporter, TestCase, TestResult, TestStatus } from '@playwright/tes
 import { ZephyrService } from './zephyr.service';
 
 function convertPwStatusToZephyr(status: TestStatus): ZephyrStatus {
-  if (status === 'passed') return 'Pass';
-  if (status === 'failed') return 'Fail';
+  if (status === 'passed') return 'Passed';
+  if (status === 'failed') return 'Failed';
   if (status === 'skipped') return 'Not Executed';
   if (status === 'timedOut') return 'Blocked';
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,8 +4,8 @@ import type { Reporter, TestCase, TestResult, TestStatus } from '@playwright/tes
 import { ZephyrService } from './zephyr.service';
 
 function convertPwStatusToZephyr(status: TestStatus): ZephyrStatus {
-  if (status === 'passed') return 'Pass';
-  if (status === 'failed') return 'Fail';
+  if (status === 'passed') return 'Passed';
+  if (status === 'failed') return 'Failed';
   if (status === 'skipped') return 'Not Executed';
   if (status === 'timedOut') return 'Blocked';
 

--- a/types/zephyr.types.ts
+++ b/types/zephyr.types.ts
@@ -9,7 +9,7 @@ export interface ZephyrOptions extends AxiosRequestConfig {
   environment?: string;
 }
 
-export type ZephyrStatus = 'Pass' | 'Fail' | 'Blocked' | 'Not Executed' | 'In Progress';
+export type ZephyrStatus = 'Passed' | 'Failed' | 'Blocked' | 'Not Executed' | 'In Progress';
 
 export type ZephyrTestResult = {
   testCaseKey: string;


### PR DESCRIPTION
zephyr was reporting all tests as `Blocked`. the status key changed. this updates it