### PR TITLE
feat(reporter): add `ignoreFailedRetries` option to avoid duplicate results during retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ const config: PlaywrightTestConfig = {
 }
 ```
 
+### Optional: Ignore failed retries
+
+To avoid duplicate "blocked" test results in Zephyr (especially if the test passes after a retry), you can enable the following option:
+
+```ts
+reporter: [['playwright-zephyr', {
+  host: 'https://jira.your-company-domain.com/',
+  authorizationToken: 'SVSdrtwgDSA312342--',
+  projectKey: 'JARV',
+  ignoreFailedRetries: true, // ← Add this to ignore intermediate retry failures
+}]]
+```
+
+When enabled, only the first successful or skipped retry will be reported. Failed retries are skipped unless the test ultimately fails all attempts.
+
 If you want to use **Cloud** reporter, you need to specify `cloud` option:
 
 ```typescript

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -15,9 +15,11 @@ export default class ZephyrReporter implements Reporter {
   private projectKey!: string;
   private testCaseKeyPattern = /\[(.*?)\]/;
   private options: ZephyrOptions;
+  private readonly ignoreFailedRetries: boolean;
 
   constructor(options: ZephyrOptions) {
     this.options = validateOptions(options);
+    this.ignoreFailedRetries = this.options.ignoreFailedRetries || false;
   }
 
   async onBegin() {
@@ -27,6 +29,9 @@ export default class ZephyrReporter implements Reporter {
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
+    if (this.ignoreFailedRetries && test.retries !== result.retry && result.status !== 'passed') {
+      return;
+    }
     if (test.title.match(this.testCaseKeyPattern) && test.title.match(this.testCaseKeyPattern)!.length > 1) {
       const [, testCaseId] = test.title.match(this.testCaseKeyPattern)!;
       const testCaseKey = `${this.projectKey}-${testCaseId}`;

--- a/src/convert-status.ts
+++ b/src/convert-status.ts
@@ -5,6 +5,7 @@ export interface ZephyrOptions extends AxiosRequestConfig {
   projectKey: string;
   testCycle?: ZephyrTestCycle;
   nodeInternalTlsRejectUnauthorized?: '0' | '1'; // NODE_TLS_REJECT_UNAUTHORIZED
+  ignoreFailedRetries?: boolean;
 }
 
 export type ZephyrStatus = 'Passed' | 'Failed' | 'Blocked' | 'Not Executed' | 'In Progress';

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,10 +18,12 @@ class ZephyrReporter implements Reporter {
   private projectKey!: string;
   private testCaseKeyPattern = /\[(.*?)\]/;
   private options: ZephyrOptions;
+  private readonly ignoreFailedRetries: boolean;
   environment: string | undefined;
 
   constructor(options: ZephyrOptions) {
     this.options = options;
+    this.ignoreFailedRetries = options.ignoreFailedRetries || false;
   }
 
   async onBegin() {
@@ -32,6 +34,9 @@ class ZephyrReporter implements Reporter {
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
+    if (this.ignoreFailedRetries && test.retries !== result.retry && result.status !== 'passed') {
+      return;
+    }
     if (test.title.match(this.testCaseKeyPattern) && test.title.match(this.testCaseKeyPattern)!.length > 1) {
       const [, projectName] = test.titlePath();
       const [, testCaseId] = test.title.match(this.testCaseKeyPattern)!;

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,10 +18,12 @@ class ZephyrReporter implements Reporter {
   private projectKey!: string;
   private testCaseKeyPattern = /\[(.*?)\]/;
   private options: ZephyrOptions;
+  private readonly ignoreFailedRetries: boolean;
   environment: string | undefined;
 
   constructor(options: ZephyrOptions) {
     this.options = options;
+    this.ignoreFailedRetries = options.ignoreFailedRetries || false;
   }
 
   async onBegin() {
@@ -32,6 +34,9 @@ class ZephyrReporter implements Reporter {
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
+    if (this.ignoreFailedRetries && test.retries !== result.retry && result.status !== 'passed') {
+      return;
+    }
     if (test.title.match(this.testCaseKeyPattern) && test.title.match(this.testCaseKeyPattern)!.length > 1) {
       const [, projectName] = test.titlePath();
       const [, testCaseId] = test.title.match(this.testCaseKeyPattern)!;

--- a/tests/ignore-retries.test.ts
+++ b/tests/ignore-retries.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * This test suite simulates a test that passes after a retry.
+ * Make sure "ignoreFailedRetries" is set to true in the Playwright config
+ * before running this test to properly validate reporter behavior.
+ */
+test.describe.configure({ retries: 2 });
+
+test('[C70] should pass after a retry and be reported once', async ({ page }, testInfo) => {
+  // Simulate a failure on first attempt
+  if (testInfo.retry === 0) {
+    expect(false).toBeTruthy();
+  }
+
+  await page.goto('https://playwright.dev');
+  await expect(page).toHaveTitle(/Playwright/);
+});

--- a/types/zephyr.types.ts
+++ b/types/zephyr.types.ts
@@ -7,6 +7,7 @@ export interface ZephyrOptions extends AxiosRequestConfig {
   authorizationToken?: string;
   projectKey: string;
   environment?: string;
+  ignoreFailedRetries?: boolean;
 }
 
 export type ZephyrStatus = 'Pass' | 'Fail' | 'Blocked' | 'Not Executed' | 'In Progress';


### PR DESCRIPTION
### What

This MR introduces a new reporter option: `ignoreFailedRetries`.

When enabled, the reporter will skip all failed retry attempts if the test eventually passes. This helps reduce noise and avoids sending multiple results for the same test case.

### Why

In Zephyr, each retry attempt can create a separate test result with a different status (e.g. "blocked", "failed") within the same test cycle. This leads to confusion and inflated reporting, even when the test eventually succeeds.

By enabling `ignoreFailedRetries`, only the first successful retry is reported — resulting in cleaner and more accurate test cycles.

### Changes

- ✅ Added `ignoreFailedRetries` flag to the reporter config (default: `false`)
- ✅ Implemented filtering logic in `onTestEnd`
- ✅ Updated README with usage example and rationale
- ✅ Added test to verify `ignoreFailedRetries` behavior

### Backward Compatibility

- ✅ Feature is **disabled by default**, preserving current behavior for existing users