### PR TITLE
Add ability to set Zephyr scale test ids via annotations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ZEPHYR_AUTHORIZATION_TOKEN=MySecretTokenValueHere

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+# Dotenv environment variables file
+.env
+
+test-results/
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ test('[J79] basic test', async ({ page }) => {
 });
 ```
 
+You can also use annotations to set the test id, note this supports multiple test ids.
+```typescript
+test('An annotated test', {
+  annotation: [
+      { type: 'zephyrTestId', description: 'T2' },
+      { type: 'zephyrTestId', description: 'T3' }
+  ]
+}, async ({page}){
+  await page.goto('https://playwright.dev/');
+  const title = page.locator('.navbar__inner .navbar__title');
+  await expect(title).toHaveText('Playwright');
+});
+
 Then run your tests with `npx playwright test` command and you'll see the result in console:
 
 ```sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.36.2",
+        "dotenv": "^17.2.3",
         "prettier": "^3.0.1",
         "release-it": "^19.0.2",
         "typescript": "^5.1.6"
@@ -780,6 +781,19 @@
         }
       }
     },
+    "node_modules/c12/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1058,9 +1072,9 @@
       "license": "MIT"
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -3384,6 +3398,14 @@
         "perfect-debounce": "^1.0.0",
         "pkg-types": "^2.1.0",
         "rc9": "^2.1.2"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "16.6.1",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+          "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+          "dev": true
+        }
       }
     },
     "call-bind-apply-helpers": {
@@ -3562,9 +3584,9 @@
       "dev": true
     },
     "dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
       "dev": true
     },
     "dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -37,15 +37,16 @@
   "homepage": "https://github.com/elaichenkov/playwright-zephyr#readme",
   "devDependencies": {
     "@playwright/test": "^1.36.2",
+    "dotenv": "^17.2.3",
     "prettier": "^3.0.1",
     "release-it": "^19.0.2",
     "typescript": "^5.1.6"
   },
   "dependencies": {
+    "@types/adm-zip": "^0.5.0",
+    "adm-zip": "^0.5.10",
     "axios": "^1.4.0",
     "picocolors": "^1.0.0",
-    "table": "^6.8.1",
-    "@types/adm-zip": "^0.5.0",
-    "adm-zip": "^0.5.10"
+    "table": "^6.8.1"
   }
 }

--- a/playwright.cloud.config.ts
+++ b/playwright.cloud.config.ts
@@ -1,14 +1,14 @@
 // playwright.config.ts
 import { PlaywrightTestConfig } from '@playwright/test';
+import * as dotenv from 'dotenv';
+
+dotenv.config({ path: '.env' });
 
 const config: PlaywrightTestConfig = {
-  reporter: [['list'], ['./src', { 
-    host: '',
-    runName: '',
-    user: '',
-    password: '',
-    authorizationToken: '',
-    projectKey: ''
+  reporter: [['list'], ['./src/cloud', { 
+    runName: `testrun-${new Date().getTime()}`,
+    authorizationToken: process.env.ZEPHYR_AUTHORIZATION_TOKEN,
+    projectKey: 'QE'
   }]],
   use: {
       screenshot: 'only-on-failure'

--- a/src/cloud.ts
+++ b/src/cloud.ts
@@ -13,7 +13,8 @@ export default class ZephyrReporter implements Reporter {
   private zephyrService!: ZephyrService;
   private testResults: ZephyrTestResult[] = [];
   private projectKey!: string;
-  private testCaseKeyPattern = /\[(.*?)\]/;
+  private readonly testCaseKeyPattern = /\[(.*?)\]/;
+  private readonly ansiRegex = /\x1b\[[0-9;]*m/g;
   private options: ZephyrOptions;
 
   constructor(options: ZephyrOptions) {
@@ -27,27 +28,39 @@ export default class ZephyrReporter implements Reporter {
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
+    let testCaseIds: string[] | undefined;
     if (test.title.match(this.testCaseKeyPattern) && test.title.match(this.testCaseKeyPattern)!.length > 1) {
       const [, testCaseId] = test.title.match(this.testCaseKeyPattern)!;
-      const testCaseKey = `${this.projectKey}-${testCaseId}`;
-      const status = convertStatus(result.status);
-      const comment = result.error
-        ? `<b>❌ Error Message: </b> <br> <span style="color: rgb(226, 80, 65);">${result.error?.message?.replaceAll(
-            '\n',
-            '<br>',
-          )}</span> <br> <br> <b>🧱 Stack Trace:</b> <br> <span style="color: rgb(226, 80, 65);">${result.error?.stack?.replaceAll(
-            '\n',
-            '<br>',
-          )}</span>`
-        : undefined;
+      if(testCaseId) testCaseIds = [testCaseId];
+    } else if(test.annotations.some(annotation => annotation.type === 'zephyrTestId')){
+      testCaseIds = test.annotations
+        .filter(annotation => annotation.type === 'zephyrTestId')
+        .map(annotation => annotation.description || '');  
+    }
 
-      this.testResults.push({
-        result: status,
-        testCase: {
-          key: testCaseKey,
-          comment,
-        },
-      });
+    if(testCaseIds) {
+      for (const testCaseId of testCaseIds) {
+
+        const testCaseKey = `${this.projectKey}-${testCaseId}`;
+        const status = convertStatus(result.status);
+        const comment = result.error
+          ? `<b>❌ Error Message: </b> <br> <span style="color: rgb(226, 80, 65);">${this.stripAnsiCodes(result.error?.message)?.replaceAll(
+              '\n',
+              '<br>',
+            )}</span> <br> <br> <b>🧱 Stack Trace:</b> <br> <span style="color: rgb(226, 80, 65);">${this.stripAnsiCodes(result.error?.stack)?.replaceAll(
+              '\n',
+              '<br>',
+            )}</span>`
+          : undefined;
+
+        this.testResults.push({
+          result: status,
+          testCase: {
+            key: testCaseKey,
+            comment,
+          },
+        });
+      }
     }
   }
 
@@ -64,4 +77,9 @@ export default class ZephyrReporter implements Reporter {
       console.log(gray(`[zephyr reporter]: There's no Zephyr test case id in this spec file`));
     }
   }
+
+  private stripAnsiCodes(str: string | undefined): string | undefined {
+    return str?.replaceAll(this.ansiRegex, '');
+  }
+
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,17 +32,29 @@ class ZephyrReporter implements Reporter {
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
+    let testCaseIds: string[] | undefined;
     if (test.title.match(this.testCaseKeyPattern) && test.title.match(this.testCaseKeyPattern)!.length > 1) {
-      const [, projectName] = test.titlePath();
       const [, testCaseId] = test.title.match(this.testCaseKeyPattern)!;
-      const testCaseKey = `${this.projectKey}-${testCaseId}`;
-      const status = convertPwStatusToZephyr(result.status);
-      this.testResults.push({
-        testCaseKey,
-        status,
-        environment: this.environment ?? projectName ?? 'Playwright',
-        executionDate: new Date().toISOString(),
-      });
+      if(testCaseId) testCaseIds = [testCaseId];
+    } else if(test.annotations.some(annotation => annotation.type === 'zephyrTestId')){
+      testCaseIds = test.annotations
+        .filter(annotation => annotation.type === 'zephyrTestId')
+        .map(annotation => annotation.description || '');  
+    }
+
+    if(testCaseIds) {
+      for (const testCaseId of testCaseIds) {
+        const [, projectName] = test.titlePath();
+        const testCaseKey = `${this.projectKey}-${testCaseId}`;
+        const status = convertPwStatusToZephyr(result.status);
+        
+        this.testResults.push({
+          testCaseKey,
+          status,
+          environment: this.environment ?? projectName ?? 'Playwright',
+          executionDate: new Date().toISOString(),
+        });
+      }
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,18 +32,29 @@ class ZephyrReporter implements Reporter {
   }
 
   onTestEnd(test: TestCase, result: TestResult) {
+    let testCaseIds: string[] | undefined;
     if (test.title.match(this.testCaseKeyPattern) && test.title.match(this.testCaseKeyPattern)!.length > 1) {
-      const [, projectName] = test.titlePath();
       const [, testCaseId] = test.title.match(this.testCaseKeyPattern)!;
-      const testCaseKey = `${this.projectKey}-${testCaseId}`;
-      const status = convertPwStatusToZephyr(result.status);
+      if(testCaseId) testCaseIds = [testCaseId];
+    } else if(test.annotations.some(annotation => annotation.type === 'zephyrTestId')){
+      testCaseIds = test.annotations
+        .filter(annotation => annotation.type === 'zephyrTestId')
+        .map(annotation => annotation.description || '');  
+    }
 
-      this.testResults.push({
-        testCaseKey,
-        status,
-        environment: this.environment ?? projectName ?? 'Playwright Test',
-        executionDate: new Date().toISOString(),
-      });
+    if(testCaseIds) {
+      for (const testCaseId of testCaseIds) {
+        const [, projectName] = test.titlePath();
+        const testCaseKey = `${this.projectKey}-${testCaseId}`;
+        const status = convertPwStatusToZephyr(result.status);
+
+        this.testResults.push({
+          testCaseKey,
+          status,
+          environment: this.environment ?? projectName ?? 'Playwright Test',
+          executionDate: new Date().toISOString(),
+        });
+      }
     }
   }
 

--- a/tests/annotated.test.ts
+++ b/tests/annotated.test.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test";
+
+test('annotated test', {
+    annotation: [{ type: 'zephyrTestId', description: 'T1' }]
+}, async ({page}) => {
+    await page.goto('https://playwright.dev/');
+    const title = page.locator('.navbar__inner .navbar__title');
+    await expect(title).toHaveText('Playwright');
+})
+
+test('Can annotate tests with multiple Zephyr IDs', {
+    annotation: [
+        { type: 'zephyrTestId', description: 'T2' },
+        { type: 'zephyrTestId', description: 'T3' }
+    ]
+}, async ({page}) => {
+        await page.goto('https://playwright.dev/');
+        const title = page.locator('.navbar__inner .navbar__title');
+        await expect(title).toHaveText('Playwright');
+    }
+)
+
+test.fail('Failed test with Zephyr ID', {
+    annotation: [{ type: 'zephyrTestId', description: 'T1' }]
+}, async ({page}) => {
+    await page.goto('https://playwright.dev/');
+    const title = page.locator('.navbar__inner .navbar__title');
+    await expect(title).toHaveText('Playright'); // Intentional typo to cause failure
+})


### PR DESCRIPTION
Closes https://github.com/elaichenkov/playwright-zephyr/issues/86
Closes https://github.com/elaichenkov/playwright-zephyr/issues/214

* Adds support for setting test ids via annotations
* Adds support for setting multiple test cases
* Fixes formatting with cloud's comments where comments contained ANSI pollution
* Adds dotenv a dev package so I don't have to remember to remove my tokens from the config files
* Adds a second config for testing via cloud (I don't have access to server, if someone who does could test these changes that would be great.)
* adds some tests for annotation driven test ids
* Adds information to the readme about annotation test ids